### PR TITLE
fix absolute paths on unix systems

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ function _mkdir(dir, mode) {
 
 module.exports = function mkdir(dir, mode) {
     var paths = dir.split(path.sep);
+    if (paths[0] === '') {
+      paths[0] = path.sep;
+    }
     return paths.reduce(function (promise, fp) {
         return promise.then(function (prev) {
             fp = path.join(prev, fp);
@@ -42,7 +45,7 @@ module.exports = function mkdir(dir, mode) {
                     if (stats.isDirectory()) {
                         return fp;
                     } else {
-                        var err = new Error("Conot create directory " + fp + ": Not a directory.");
+                        var err = new Error("Cannot create directory " + fp + ": Not a directory.");
                         return Promise.reject(err);
                     }
                 });

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -1,6 +1,7 @@
 var assert = require("assert");
 var mkdir = require("../index");
 var child_process = require("child_process");
+var path = require('path');
 
 describe("mkdir -p foo/bar", function () {
     var cwd;
@@ -12,6 +13,15 @@ describe("mkdir -p foo/bar", function () {
     it("should return foo/bar", function (done) {
         mkdir("foo/bar").then(function (rst) {
             assert.equal(rst, "foo/bar");
+            done();
+        }).catch(function (ex) {
+            done(ex);
+        });
+    });
+    it("should handle absolute paths", function (done) {
+        var absolutePath = path.join(__dirname, "foo", "bar");
+        mkdir(absolutePath).then(function (rst) {
+            assert.equal(rst, absolutePath);
             done();
         }).catch(function (ex) {
             done(ex);


### PR DESCRIPTION
Heya.

If I call mkdir-promise with an absolute path (`'/a/b/c'`), the split with the path separator will create an array with `['', 'a', 'b', 'c']`. When iterating over this array, the empty string will be handled as the current directory and so the path will be relative to the pwd.
My solution is, to replace a first empty element with the path separator. Every check with `path.isAbsolute` will cause further handling as Windows paths do not start with a path separator, so I think this is the simplest solution.
